### PR TITLE
Update 2019-05-24-lichtenberg19a.md

### DIFF
--- a/_posts/2019-05-24-lichtenberg19a.md
+++ b/_posts/2019-05-24-lichtenberg19a.md
@@ -35,12 +35,12 @@ editor:
   family: Chaudhuri
 - given: Ruslan
   family: Salakhutdinov
-bibtex_author: Lichtenberg, Jan and {\c{S}im\c{s}ek}, {\"{O}}zg\"{u}r
+bibtex_author: Lichtenberg, Jan Malte and {\c{S}im\c{s}ek}, {\"{O}}zg\"{u}r
 author:
-- given: Jan
+- given: Jan Malte
   family: Lichtenberg
-- given: ''
-  family: Simsek
+- given: Özgür
+  family: Şimşek
 date: 2019-05-24
 container-title: Proceedings of the 36th International Conference on Machine Learning
 genre: inproceedings


### PR DESCRIPTION
Added given name(s) and accents to the "author" field. They were only given in the "bibtex_author" field.