### PR TITLE
Update 2019-05-24-ding19b.md

### DIFF
--- a/_posts/2019-05-24-ding19b.md
+++ b/_posts/2019-05-24-ding19b.md
@@ -32,7 +32,7 @@ editor:
 - given: Ruslan
   family: Salakhutdinov
 bibtex_author: Ding, Tianyu and Zhu, Zhihui and Ding, Tianjiao and Yang, Yunchen and
-Vidal, Rene and Tsakiris, Manolis and Robinson, Daniel
+ Vidal, Rene and Tsakiris, Manolis and Robinson, Daniel
 author:
 - given: Tianyu
   family: Ding


### PR DESCRIPTION
Missed a space between author names before, and the page cannot be rendered correctly. Fix this now.