### PR TITLE
Fix "Nicolas Le Roux" in the citation

### DIFF
--- a/_posts/2019-05-24-ahmed19a.md
+++ b/_posts/2019-05-24-ahmed19a.md
@@ -34,7 +34,7 @@ editor:
   family: Chaudhuri
 - given: Ruslan
   family: Salakhutdinov
-bibtex_author: Ahmed, Zafarali and Roux, Nicolas Le and Norouzi, Mohammad and Schuurmans,
+bibtex_author: Ahmed, Zafarali and Le Roux, Nicolas and Norouzi, Mohammad and Schuurmans,
   Dale
 author:
 - given: Zafarali


### PR DESCRIPTION
Le Roux is last name and therefore should appear as Le Roux, N.